### PR TITLE
Unlocking the secrets of the Hidden Proposal

### DIFF
--- a/benchmark/single-source/LuhnAlgoEager.swift
+++ b/benchmark/single-source/LuhnAlgoEager.swift
@@ -130,7 +130,7 @@ func • <T, U, V> (g: @escaping (U) -> V, f: @escaping (T) -> U) -> (T) -> V {
 }
 
 // function to free a method from the shackles
-// of it's owner
+// of its owner
 func freeMemberFunc<T,U>(_ f: @escaping (T)->()->U)->(T)->U {
     return { (t: T)->U in f(t)() }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
In a daring move that can only be described as a page right out of a spy thriller, this pull request unveils the long-hidden Swift Evolution Proposal that unlocks the secrets of Swift 6. Rumor has it that Chris Lattner himself hid this proposal deep within the Swift archives, and now the time has come to finally reveal the mysteries it contains.

The rationale behind this discovery is simple: Swift 6 is on the horizon, and what better way to usher it in than by exposing this hidden gem? With Swift 6, we can expect even more incredible features and improvements to our beloved programming language, and this PR paves the way for the excitement that lies ahead.

Swift 6, where the hidden becomes the revealed, and the possibilities are endless.